### PR TITLE
Demos: Refactor layout in MainLayout.razor and Index.razor

### DIFF
--- a/BlazorExpress.Bulma.Demo.RCL/Layout/MainLayout.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Layout/MainLayout.razor
@@ -8,22 +8,24 @@
                        ApplicationName="BlazorExpress.Bulma" />
     </HeaderSection>
     <ContentSection>
-        @Body
-        <div class="container is-max-desktop mb-4">
-            <MainLayoutBaseFooter NugetPackageName="@NugetPackageName"
-                                  NugetPackageDisplayName="@NugetPackageDisplayName"
-                                  Version="@Version"
-                                  DotNetVersion="@DotNetVersion"
-                                  DocsUrl="@DocsUrl"
-                                  BlogUrl="@BlogUrl"
-                                  GithubUrl="@GithubUrl"
-                                  NugetUrl="@NuGetUrl"
-                                  TwitterUrl="@TwitterUrl"
-                                  LinkedInUrl="@LinkedInUrl"
-                                  OpenCollectiveUrl="@OpenCollectiveUrl"
-                                  GithubIssuesUrl="@GithubIssuesUrl"
-                                  GithubDiscussionsUrl="@GithubDiscussionsUrl"
-                                  StackoverflowUrl="@StackoverflowUrl" />
+        <div class="be-bulma-masthead p-5">
+            @Body
+            <div class="container is-max-desktop mb-4">
+                <MainLayoutBaseFooter NugetPackageName="@NugetPackageName"
+                                      NugetPackageDisplayName="@NugetPackageDisplayName"
+                                      Version="@Version"
+                                      DotNetVersion="@DotNetVersion"
+                                      DocsUrl="@DocsUrl"
+                                      BlogUrl="@BlogUrl"
+                                      GithubUrl="@GithubUrl"
+                                      NugetUrl="@NuGetUrl"
+                                      TwitterUrl="@TwitterUrl"
+                                      LinkedInUrl="@LinkedInUrl"
+                                      OpenCollectiveUrl="@OpenCollectiveUrl"
+                                      GithubIssuesUrl="@GithubIssuesUrl"
+                                      GithubDiscussionsUrl="@GithubDiscussionsUrl"
+                                      StackoverflowUrl="@StackoverflowUrl" />
+            </div>
         </div>
     </ContentSection>
     <FooterSection>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Home/Index.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Home/Index.razor
@@ -2,7 +2,7 @@
 
 <PageMetaTags PageUrl="@pageUrl" Title="@metaTitle" Description="@metaDescription" ImageUrl="@imageUrl" />
 
-<div class="be-bulma-masthead has-text-centered">
+<div class="has-text-centered">
     <div class="container is-max-desktop mb-4">
         <div class="mb-6">
             <div class="pt-6 mb-6">


### PR DESCRIPTION
- Restructured `MainLayout.razor` by moving the `@Body` directive into a new `div` with the class `be-bulma-masthead`, enhancing the visual distinction of the header while keeping the footer intact.
- Simplified `Index.razor` by removing the `be-bulma-masthead` class, maintaining centered text alignment.

NOTE: This commit message is auto-generated using GitHub Copilot.