### PR TITLE
Update BlazorExpress.Core package version

### DIFF
--- a/BlazorExpress.Bulma/BlazorExpress.Bulma.csproj
+++ b/BlazorExpress.Bulma/BlazorExpress.Bulma.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorExpress.Core" Version="0.0.4" />
+    <PackageReference Include="BlazorExpress.Core" Version="0.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the `BlazorExpress.Core` package reference in `BlazorExpress.Bulma.csproj` from version `0.0.4` to version `0.1.1`.

NOTE: This commit message is auto-generated using GitHub Copilot.