### PR TITLE
Add Google Analytics tracking code

### DIFF
--- a/BlazorExpress.Bulma.Demo.Server/Components/App.razor
+++ b/BlazorExpress.Bulma.Demo.Server/Components/App.razor
@@ -14,6 +14,17 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link rel="stylesheet" href="BlazorExpress.Bulma.Demo.Server.styles.css" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5PEH6MERND"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-5PEH6MERND');
+    </script>
+
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 

--- a/BlazorExpress.Bulma.Demo.WebAssembly/wwwroot/index.html
+++ b/BlazorExpress.Bulma.Demo.WebAssembly/wwwroot/index.html
@@ -13,6 +13,16 @@
     <link rel="stylesheet" href="_content/BlazorExpress.Bulma.Demo.RCL/css/blazorexpress.bulma.demo.rcl.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5PEH6MERND"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-5PEH6MERND');
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
This commit introduces Google Analytics tracking to both `App.razor` and `index.html`. It includes a script to load the Google Tag Manager library asynchronously and initializes tracking with the ID `G-5PEH6MERND`, enabling the collection of user interaction data.

NOTE: This commit message is auto-generated using GitHub Copilot.