### PR TITLE
Add Panel component and related features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ This file is the entry point for development agents working in this repository. 
 - Preserve the current inconsistency strategy.
   Rule: when the repository has mixed patterns, use the nearest local pattern for the file or feature you are changing and document the ambiguity if you formalize it here later.
 
-- Clarify requirement ambiguities before implementation.
-  Rule: when a requested change includes ambiguous requirements, pause before coding and resolve them through sequential clarification questions. Ask one question at a time, provide multiple-choice options plus a `Custom Answer` option, mark a recommended option, explain why it is recommended, and wait for the user's response before asking the next question or starting implementation.
+- Perform a mandatory requirement analysis before every new implementation.
+  Rule: before starting any new implementation, first analyze the provided requirements for ambiguity, missing decisions, or conflicting expectations. If any material ambiguity exists, pause before coding and resolve it through sequential clarification questions. Ask one question at a time, provide multiple-choice options plus a `Custom Answer` option, mark a recommended option, explain why it is recommended, and wait for the user's response before asking the next question or starting implementation.
+  Rule: if the requirement is already clear enough to implement safely, document that conclusion in a short user-facing note and then proceed.
   Example: if a feature request is unclear about API shape, UI behavior, or backward-compatibility expectations, ask the highest-impact unresolved question first and do not begin code changes until that ambiguity is resolved.
 
 - Clean up temporary artifacts after every implementation.

--- a/BlazorExpress.Bulma.Demo.RCL/Layout/BlogMainLayout.razor.cs
+++ b/BlazorExpress.Bulma.Demo.RCL/Layout/BlogMainLayout.razor.cs
@@ -108,6 +108,7 @@ public partial class BlogMainLayout : MainLayoutBase
                 new Link { Href = DemoRouteConstants.Demos_Message_Documentation, Text = "Message" },
                 new Link { Href = DemoRouteConstants.Demos_Modal_Documentation, Text = "Modal" },
                 new Link { Href = DemoRouteConstants.Demos_Pagination_Documentation, Text = "Pagination" },
+                new Link { Href = DemoRouteConstants.Demos_Panel_Documentation, Text = "Panel" },
                 new Link { Href = DemoRouteConstants.Demos_ScriptLoader_Documentation, Text = "Script Loader" },
                 new Link { Href = DemoRouteConstants.Demos_Tabs_Documentation, Text = "Tabs" }
             ]

--- a/BlazorExpress.Bulma.Demo.RCL/Layout/DemosMainLayout.razor.cs
+++ b/BlazorExpress.Bulma.Demo.RCL/Layout/DemosMainLayout.razor.cs
@@ -101,6 +101,7 @@ public partial class DemosMainLayout : MainLayoutBase
                 new Link { Href = DemoRouteConstants.Demos_Modal_Documentation, Text = "Modal" },
                 new Link { Href = DemoRouteConstants.Demos_Navbar_Documentation, Text = "Navbar" },
                 new Link { Href = DemoRouteConstants.Demos_Pagination_Documentation, Text = "Pagination" },
+                new Link { Href = DemoRouteConstants.Demos_Panel_Documentation, Text = "Panel" },
                 new Link { Href = DemoRouteConstants.Demos_PdfViewer_Documentation, Text = "Pdf Viewer" },
                 new Link { Href = DemoRouteConstants.Demos_ScriptLoader_Documentation, Text = "Script Loader" },
                 new Link { Href = DemoRouteConstants.Demos_Tabs_Documentation, Text = "Tabs" }

--- a/BlazorExpress.Bulma.Demo.RCL/Layout/DocsMainLayout.razor.cs
+++ b/BlazorExpress.Bulma.Demo.RCL/Layout/DocsMainLayout.razor.cs
@@ -115,6 +115,7 @@ public partial class DocsMainLayout : MainLayoutBase
                 new Link { Href = DemoRouteConstants.Docs_Modal_Documentation, Text = "Modal" },
                 new Link { Href = DemoRouteConstants.Docs_Navbar_Documentation, Text = "Navbar" },
                 new Link { Href = DemoRouteConstants.Docs_Pagination_Documentation, Text = "Pagination" },
+                new Link { Href = DemoRouteConstants.Docs_Panel_Documentation, Text = "Panel" },
                 new Link { Href = DemoRouteConstants.Docs_PdfViewer_Documentation, Text = "Pdf Viewer" },
                 new Link { Href = DemoRouteConstants.Docs_ScriptLoader_Documentation, Text = "Script Loader" },
                 new Link { Href = DemoRouteConstants.Docs_Tabs_Documentation, Text = "Tabs" }

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/PanelDocumentation.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/PanelDocumentation.razor
@@ -1,0 +1,111 @@
+@attribute [Route(pageUrl)]
+@layout DemosMainLayout
+
+<PageMetaTags PageUrl="@pageUrl" Title="@metaTitle" Description="@metaDescription" ImageUrl="@imageUrl" />
+
+<PageHero Title="@pageTitle">
+    <SubTitleTemplate>
+        @((MarkupString)pageDescription)
+    </SubTitleTemplate>
+</PageHero>
+
+<DocsLink Href="@DemoRouteConstants.Docs_Panel_Documentation" />
+
+<Section Class="p-0" Size="HeadingSize.H3" Name="How it works" PageUrl="@pageUrl" Link="how-it-works">
+    <Block>
+        The <strong>Panel</strong> component family mirrors Bulma's compact control panel structure so you can compose headings, filter tabs, interactive blocks, and icons without manually stitching together the CSS classes.
+        <br /><br />
+        <strong>How to use:</strong>
+        <div class="content mb-2">
+            <ol>
+                <li>Wrap the overall layout in <code>&lt;Panel&gt;</code>.</li>
+                <li>Add a <code>&lt;PanelHeading&gt;</code> as the title row.</li>
+                <li>Use <code>&lt;PanelTabs&gt;</code> with one or more <code>&lt;PanelTab&gt;</code> elements when you need compact filters.</li>
+                <li>Fill the body with <code>&lt;PanelBlock&gt;</code> entries and use <code>&lt;PanelIcon&gt;</code> when a block needs an icon slot.</li>
+            </ol>
+        </div>
+        This first example follows Bulma's reference layout with a search control, filter tabs, active list items, a checkbox label block, and a footer action.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_01_How_it_works)" Tabs="true" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H3" Name="Active state" PageUrl="@pageUrl" Link="active-state">
+    <Block>
+        <strong>PanelTab</strong> and <strong>PanelBlock</strong> expose an <code>IsActive</code> parameter so you can highlight the current selection inside the panel.
+        <br /><br />
+        <strong>How to use:</strong>
+        <div class="content mb-2">
+            <ol>
+                <li>Set <code>IsActive="true"</code> on the current <code>PanelTab</code> to highlight the selected filter.</li>
+                <li>Set <code>IsActive="true"</code> on the current <code>PanelBlock</code> to highlight the active item in the body of the panel.</li>
+                <li>Keep the rest of the tabs and blocks inactive so the current selection stays visually clear.</li>
+            </ol>
+        </div>
+        This example shows one active tab and one active block inside a neutral panel.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_02_Color_And_Active_State)" Tabs="true" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H3" Name="Colors" PageUrl="@pageUrl" Link="colors">
+    <Block>
+        The <strong>Panel</strong> component supports the same main Bulma color modifiers shown in the panel documentation, which makes it easy to align the panel's emphasis with the rest of your UI.
+        <br /><br />
+        <strong>How to use:</strong>
+        <div class="content mb-2">
+            <ol>
+                <li>Set the <code>Color</code> parameter on <code>Panel</code> to one of the supported values such as <code>PanelColor.Link</code>, <code>PanelColor.Primary</code>, <code>PanelColor.Info</code>, <code>PanelColor.Success</code>, <code>PanelColor.Warning</code>, or <code>PanelColor.Danger</code>.</li>
+                <li>Keep the internal structure the same with <code>PanelHeading</code>, optional <code>PanelTabs</code>, and one or more <code>PanelBlock</code> entries.</li>
+                <li>Use active tabs or blocks as needed to reinforce the currently selected item inside each color variant.</li>
+            </ol>
+        </div>
+        The following demos show the main Bulma panel color variants side by side as individually linkable examples.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_A_Link)" Tabs="true" />
+    <Block>
+        This example uses the <code>Primary</code> color to create a strong, branded panel treatment.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_B_Primary)" Tabs="true" />
+    <Block>
+        This example uses the <code>Info</code> color for status-oriented or informational panels.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_C_Info)" Tabs="true" />
+    <Block>
+        This example uses the <code>Success</code> color for completed, healthy, or approved states.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_D_Success)" Tabs="true" />
+    <Block>
+        This example uses the <code>Warning</code> color for cautionary or pending states.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_E_Warning)" Tabs="true" />
+    <Block>
+        This example uses the <code>Danger</code> color for errors, blockers, or critical states.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_04_Colors_F_Danger)" Tabs="true" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H3" Name="Block rendering" PageUrl="@pageUrl" Link="block-rendering">
+    <Block>
+        <strong>PanelBlock</strong> can render in three useful ways without requiring separate components for each case.
+        <br /><br />
+        <strong>What to expect:</strong>
+        <div class="content mb-2">
+            <ol>
+                <li>Without extra parameters, <code>PanelBlock</code> renders a <code>div</code>.</li>
+                <li>When <code>Href</code> is set, it renders an anchor block for navigable items.</li>
+                <li>When <code>IsLabel="true"</code> is set and <code>Href</code> is not provided, it renders a <code>label</code> block that works well for checkboxes and toggles.</li>
+            </ol>
+        </div>
+        This demo shows all three rendering modes in one compact panel.
+    </Block>
+    <Demo Type="typeof(Panel_Demo_03_Block_Rendering)" Tabs="true" />
+</Section>
+
+@code {
+    private const string componentName = nameof(Panel);
+    private const string pageUrl = DemoRouteConstants.Demos_Panel_Documentation;
+    private const string pageTitle = componentName;
+    private const string pageDescription = $"The <code>{componentName}</code> component family helps you build compact control panels with headings, tabs, blocks, and icon slots using Bulma markup.";
+    private const string metaTitle = $"Blazor {componentName} Component";
+    private const string metaDescription = $"The {componentName} component family helps you build compact control panels with headings, tabs, blocks, and icon slots using Bulma markup.";
+    private const string imageUrl = "";
+}

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_01_How_it_works.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_01_How_it_works.razor
@@ -1,0 +1,49 @@
+<Panel style="max-width: 24rem;">
+    <PanelHeading>Repositories</PanelHeading>
+
+    <PanelBlock>
+        <p class="control has-icons-left">
+            <input class="input" type="text" placeholder="Search" />
+            <span class="icon is-left">
+                <i class="bi bi-search" aria-hidden="true"></i>
+            </span>
+        </p>
+    </PanelBlock>
+
+    <PanelTabs>
+        <PanelTab IsActive="true">All</PanelTab>
+        <PanelTab>Public</PanelTab>
+        <PanelTab>Private</PanelTab>
+        <PanelTab>Forks</PanelTab>
+    </PanelTabs>
+
+    <PanelBlock Href="https://github.com/BlazorExpress/BlazorExpress.Bulma" IsActive="true">
+        <PanelIcon>
+            <i class="bi bi-book" aria-hidden="true"></i>
+        </PanelIcon>
+        BlazorExpress.Bulma
+    </PanelBlock>
+
+    <PanelBlock Href="https://bulma.blazorexpress.com/docs/">
+        <PanelIcon>
+            <i class="bi bi-journal-text" aria-hidden="true"></i>
+        </PanelIcon>
+        Documentation site
+    </PanelBlock>
+
+    <PanelBlock Href="https://bulma.blazorexpress.com/demos/">
+        <PanelIcon>
+            <i class="bi bi-window" aria-hidden="true"></i>
+        </PanelIcon>
+        Component demos
+    </PanelBlock>
+
+    <PanelBlock IsLabel="true">
+        <input type="checkbox" />
+        <span class="ml-2">remember me</span>
+    </PanelBlock>
+
+    <PanelBlock>
+        <button class="button is-link is-outlined is-fullwidth">Reset all filters</button>
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_02_Color_And_Active_State.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_02_Color_And_Active_State.razor
@@ -1,0 +1,31 @@
+<Panel style="max-width: 24rem;">
+    <PanelHeading>Source Type</PanelHeading>
+
+    <PanelTabs>
+        <PanelTab IsActive="true">All</PanelTab>
+        <PanelTab>Public</PanelTab>
+        <PanelTab>Private</PanelTab>
+        <PanelTab>Archived</PanelTab>
+    </PanelTabs>
+
+    <PanelBlock Href="https://github.com/BlazorExpress/BlazorExpress.Bulma/issues/43" IsActive="true">
+        <PanelIcon>
+            <i class="bi bi-pin-angle" aria-hidden="true"></i>
+        </PanelIcon>
+        Panel component issue
+    </PanelBlock>
+
+    <PanelBlock Href="https://bulma.io/documentation/components/panel/">
+        <PanelIcon>
+            <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+        </PanelIcon>
+        Bulma specification
+    </PanelBlock>
+
+    <PanelBlock Href="@DemoRouteConstants.Docs_Panel_Documentation">
+        <PanelIcon>
+            <i class="bi bi-code-square" aria-hidden="true"></i>
+        </PanelIcon>
+        API documentation
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_03_Block_Rendering.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_03_Block_Rendering.razor
@@ -1,0 +1,22 @@
+<Panel style="max-width: 24rem;">
+    <PanelHeading>Mixed block rendering</PanelHeading>
+
+    <PanelBlock>
+        <div>
+            <p class="has-text-weight-semibold mb-2">Search block</p>
+            <input class="input" type="text" placeholder="Filter components" />
+        </div>
+    </PanelBlock>
+
+    <PanelBlock IsLabel="true">
+        <input type="checkbox" checked />
+        <span class="ml-2">Include prerelease packages</span>
+    </PanelBlock>
+
+    <PanelBlock Href="https://www.nuget.org/packages/BlazorExpress.Bulma">
+        <PanelIcon>
+            <i class="bi bi-box-seam" aria-hidden="true"></i>
+        </PanelIcon>
+        View package on NuGet
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_A_Link.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_A_Link.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Link" style="max-width: 24rem;">
+    <PanelHeading>Link</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">All</PanelTab>
+        <PanelTab>Open</PanelTab>
+        <PanelTab>Closed</PanelTab>
+    </PanelTabs>
+    <PanelBlock Href="https://bulma.io/documentation/components/panel/" IsActive="true">
+        <PanelIcon><i class="bi bi-book" aria-hidden="true"></i></PanelIcon>
+        Bulma panel docs
+    </PanelBlock>
+    <PanelBlock Href="@DemoRouteConstants.Docs_Panel_Documentation">
+        <PanelIcon><i class="bi bi-code-square" aria-hidden="true"></i></PanelIcon>
+        View API docs
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_B_Primary.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_B_Primary.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Primary" style="max-width: 24rem;">
+    <PanelHeading>Primary</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">Overview</PanelTab>
+        <PanelTab>Recent</PanelTab>
+        <PanelTab>Saved</PanelTab>
+    </PanelTabs>
+    <PanelBlock Href="https://github.com/BlazorExpress/BlazorExpress.Bulma/issues/43" IsActive="true">
+        <PanelIcon><i class="bi bi-pin-angle" aria-hidden="true"></i></PanelIcon>
+        Panel issue
+    </PanelBlock>
+    <PanelBlock Href="@DemoRouteConstants.Demos_Panel_Documentation">
+        <PanelIcon><i class="bi bi-window" aria-hidden="true"></i></PanelIcon>
+        View demos
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_C_Info.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_C_Info.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Info" style="max-width: 24rem;">
+    <PanelHeading>Info</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">Status</PanelTab>
+        <PanelTab>Builds</PanelTab>
+        <PanelTab>Logs</PanelTab>
+    </PanelTabs>
+    <PanelBlock IsActive="true">
+        <PanelIcon><i class="bi bi-info-circle" aria-hidden="true"></i></PanelIcon>
+        Informational panel styling
+    </PanelBlock>
+    <PanelBlock>
+        <PanelIcon><i class="bi bi-list-check" aria-hidden="true"></i></PanelIcon>
+        Great for operational summaries
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_D_Success.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_D_Success.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Success" style="max-width: 24rem;">
+    <PanelHeading>Success</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">Passed</PanelTab>
+        <PanelTab>Queued</PanelTab>
+        <PanelTab>Skipped</PanelTab>
+    </PanelTabs>
+    <PanelBlock IsActive="true">
+        <PanelIcon><i class="bi bi-check-circle" aria-hidden="true"></i></PanelIcon>
+        Validation checks passed
+    </PanelBlock>
+    <PanelBlock>
+        <PanelIcon><i class="bi bi-box-seam" aria-hidden="true"></i></PanelIcon>
+        Package is ready to publish
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_E_Warning.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_E_Warning.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Warning" style="max-width: 24rem;">
+    <PanelHeading>Warning</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">Attention</PanelTab>
+        <PanelTab>Pending</PanelTab>
+        <PanelTab>Later</PanelTab>
+    </PanelTabs>
+    <PanelBlock IsActive="true">
+        <PanelIcon><i class="bi bi-exclamation-triangle" aria-hidden="true"></i></PanelIcon>
+        Check incomplete configuration
+    </PanelBlock>
+    <PanelBlock>
+        <PanelIcon><i class="bi bi-hourglass-split" aria-hidden="true"></i></PanelIcon>
+        Review before continuing
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_F_Danger.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Demos/Panel/Panel_Demo_04_Colors_F_Danger.razor
@@ -1,0 +1,16 @@
+<Panel Color="PanelColor.Danger" style="max-width: 24rem;">
+    <PanelHeading>Danger</PanelHeading>
+    <PanelTabs>
+        <PanelTab IsActive="true">Errors</PanelTab>
+        <PanelTab>Alerts</PanelTab>
+        <PanelTab>Blocked</PanelTab>
+    </PanelTabs>
+    <PanelBlock IsActive="true">
+        <PanelIcon><i class="bi bi-x-octagon" aria-hidden="true"></i></PanelIcon>
+        Critical issue detected
+    </PanelBlock>
+    <PanelBlock>
+        <PanelIcon><i class="bi bi-bug" aria-hidden="true"></i></PanelIcon>
+        Resolve blockers before release
+    </PanelBlock>
+</Panel>

--- a/BlazorExpress.Bulma.Demo.RCL/Pages/Docs/Panel/Panel_Doc_01_Documentation.razor
+++ b/BlazorExpress.Bulma.Demo.RCL/Pages/Docs/Panel/Panel_Doc_01_Documentation.razor
@@ -1,0 +1,83 @@
+@attribute [Route(pageUrl)]
+@layout DocsMainLayout
+
+<PageMetaTags PageUrl="@pageUrl" Title="@metaTitle" Description="@metaDescription" ImageUrl="@imageUrl" />
+
+<PageHero Title="@pageTitle">
+    <SubTitleTemplate>
+        @((MarkupString)pageDescription)
+    </SubTitleTemplate>
+</PageHero>
+
+<DemoLink Href="@DemoRouteConstants.Demos_Panel_Documentation" />
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="Preview" PageUrl="@pageUrl" Link="preview">
+    <div style="max-width: 24rem;">
+        <Panel Color="PanelColor.Primary">
+            <PanelHeading>Panel component</PanelHeading>
+            <PanelTabs>
+                <PanelTab IsActive="true">All</PanelTab>
+                <PanelTab>Open</PanelTab>
+                <PanelTab>Closed</PanelTab>
+            </PanelTabs>
+            <PanelBlock Href="https://bulma.io/documentation/components/panel/" IsActive="true">
+                <PanelIcon>
+                    <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                </PanelIcon>
+                Bulma specification
+            </PanelBlock>
+            <PanelBlock Href="@DemoRouteConstants.Demos_Panel_Documentation">
+                <PanelIcon>
+                    <i class="bi bi-window" aria-hidden="true"></i>
+                </PanelIcon>
+                View demos
+            </PanelBlock>
+        </Panel>
+    </div>
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelBlock Notes" PageUrl="@pageUrl" Link="panelblock-notes">
+    <div class="content">
+        <ul>
+            <li><code>PanelBlock</code> renders a <code>div</code> by default.</li>
+            <li>When <code>Href</code> is provided, <code>PanelBlock</code> renders an anchor element.</li>
+            <li>When <code>IsLabel</code> is <code>true</code> and <code>Href</code> is not provided, <code>PanelBlock</code> renders a label element.</li>
+            <li><code>PanelIcon</code> is optional and can wrap raw icon markup or another icon component inside a block.</li>
+            <li><code>Panel.Color</code> supports the main Bulma panel color variants, including <code>Link</code>, <code>Primary</code>, <code>Info</code>, <code>Success</code>, <code>Warning</code>, and <code>Danger</code>.</li>
+        </ul>
+    </div>
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="Panel Parameters" PageUrl="@pageUrl" Link="panel-parameters">
+    <DocxTable TItem="Panel" DocType="DocType.Parameters" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelHeading Parameters" PageUrl="@pageUrl" Link="panel-heading-parameters">
+    <DocxTable TItem="PanelHeading" DocType="DocType.Parameters" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelTabs Parameters" PageUrl="@pageUrl" Link="panel-tabs-parameters">
+    <DocxTable TItem="PanelTabs" DocType="DocType.Parameters" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelTab Parameters" PageUrl="@pageUrl" Link="panel-tab-parameters">
+    <DocxTable TItem="PanelTab" DocType="DocType.Parameters" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelBlock Parameters" PageUrl="@pageUrl" Link="panel-block-parameters">
+    <DocxTable TItem="PanelBlock" DocType="DocType.Parameters" />
+</Section>
+
+<Section Class="p-0" Size="HeadingSize.H4" Name="PanelIcon Parameters" PageUrl="@pageUrl" Link="panel-icon-parameters">
+    <DocxTable TItem="PanelIcon" DocType="DocType.Parameters" />
+</Section>
+
+@code {
+    private const string componentName = nameof(Panel);
+    private const string pageUrl = DemoRouteConstants.Docs_Panel_Documentation;
+    private const string pageTitle = componentName;
+    private const string pageDescription = $"This documentation provides a comprehensive reference for the <code>{componentName}</code> component family, including its heading, tabs, blocks, and icon helpers.";
+    private const string metaTitle = $"Blazor {componentName} Component";
+    private const string metaDescription = $"This documentation provides a comprehensive reference for the {componentName} component family, including its heading, tabs, blocks, and icon helpers.";
+    private const string imageUrl = "";
+}

--- a/BlazorExpress.Bulma.Demo.RCL/Utils/DemoPageLinkUtil.cs
+++ b/BlazorExpress.Bulma.Demo.RCL/Utils/DemoPageLinkUtil.cs
@@ -104,7 +104,7 @@ public static class DemoPageLinkUtil
         links.Add(new PageLink { Id = index, IconName = BootstrapIconName.ThreeDots, Href = DemoRouteConstants.Demos_Pagination_Documentation, Text = "Pagination", Categories = new() { DemoPageLinkCategory.All, DemoPageLinkCategory.Components }, Status = PageLinkStatus.None, IsActive = true });
 
         index += 1;
-        links.Add(new PageLink { Id = index, IconName = BootstrapIconName.None, Href = DemoRouteConstants.Demos_Panel_Documentation, Text = "Panel", Categories = new() { DemoPageLinkCategory.All, DemoPageLinkCategory.Components }, Status = PageLinkStatus.None, IsActive = false });
+        links.Add(new PageLink { Id = index, IconName = BootstrapIconName.LayoutSidebarInset, Href = DemoRouteConstants.Demos_Panel_Documentation, Text = "Panel", Categories = new() { DemoPageLinkCategory.All, DemoPageLinkCategory.Components }, Status = PageLinkStatus.New, IsActive = true });
 
         index += 1;
         links.Add(new PageLink { Id = index, IconName = BootstrapIconName.None, Href = DemoRouteConstants.Demos_Form_PasswordInput_Documentation, Text = "Password Input", Categories = new() { DemoPageLinkCategory.All, DemoPageLinkCategory.Form }, Status = PageLinkStatus.None, IsActive = false });

--- a/BlazorExpress.Bulma/Components/Panel/Panel.razor
+++ b/BlazorExpress.Bulma/Components/Panel/Panel.razor
@@ -1,0 +1,6 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+<nav @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+    @ChildContent
+</nav>

--- a/BlazorExpress.Bulma/Components/Panel/Panel.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/Panel.razor.cs
@@ -1,0 +1,46 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// Panel component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class Panel : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames =>
+        BuildClassNames(
+            Class,
+            (BulmaCssClass.Panel, true),
+            (Color.ToPanelColorClass(), Color != PanelColor.None)
+        );
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the panel color.
+    /// <para>
+    /// Default value is <see cref="PanelColor.None" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(PanelColor.None)]
+    [Description("Gets or sets the panel color.")]
+    [Parameter]
+    public PanelColor Color { get; set; } = PanelColor.None;
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelBlock.razor
+++ b/BlazorExpress.Bulma/Components/Panel/PanelBlock.razor
@@ -1,0 +1,21 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+@if (RenderAsLink)
+{
+    <a @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" href="@Href" @attributes="@AdditionalAttributes">
+        @ChildContent
+    </a>
+}
+else if (RenderAsLabel)
+{
+    <label @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+        @ChildContent
+    </label>
+}
+else
+{
+    <div @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+        @ChildContent
+    </div>
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelBlock.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/PanelBlock.razor.cs
@@ -1,0 +1,74 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// PanelBlock component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class PanelBlock : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames =>
+        BuildClassNames(
+            Class,
+            (BulmaCssClass.PanelBlock, true),
+            (BulmaCssClass.IsActive, IsActive)
+        );
+
+    private bool RenderAsLabel => !RenderAsLink && IsLabel;
+
+    private bool RenderAsLink => !string.IsNullOrWhiteSpace(Href);
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hyperlink reference. If set, the panel block renders an anchor element.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the hyperlink reference. If set, the panel block renders an anchor element.")]
+    [Parameter]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// Gets or sets the active state.
+    /// <para>
+    /// Default value is <see langword="false" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(false)]
+    [Description("Gets or sets the active state.")]
+    [Parameter]
+    public bool IsActive { get; set; } = false;
+
+    /// <summary>
+    /// If <see langword="true" />, the panel block renders a label element when <see cref="Href" /> is not set.
+    /// <para>
+    /// Default value is <see langword="false" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(false)]
+    [Description("If <b>true</b>, the panel block renders a label element when <code>Href</code> is not set.")]
+    [Parameter]
+    public bool IsLabel { get; set; } = false;
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelHeading.razor
+++ b/BlazorExpress.Bulma/Components/Panel/PanelHeading.razor
@@ -1,0 +1,6 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+<p @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+    @ChildContent
+</p>

--- a/BlazorExpress.Bulma/Components/Panel/PanelHeading.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/PanelHeading.razor.cs
@@ -1,0 +1,29 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// PanelHeading component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class PanelHeading : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames => BuildClassNames(Class, (BulmaCssClass.PanelHeading, true));
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelIcon.razor
+++ b/BlazorExpress.Bulma/Components/Panel/PanelIcon.razor
@@ -1,0 +1,6 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+<span @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+    @ChildContent
+</span>

--- a/BlazorExpress.Bulma/Components/Panel/PanelIcon.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/PanelIcon.razor.cs
@@ -1,0 +1,29 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// PanelIcon component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class PanelIcon : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames => BuildClassNames(Class, (BulmaCssClass.PanelIcon, true));
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelTab.razor
+++ b/BlazorExpress.Bulma/Components/Panel/PanelTab.razor
@@ -1,0 +1,6 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+<a @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" href="@Href" @attributes="@AdditionalAttributes">
+    @ChildContent
+</a>

--- a/BlazorExpress.Bulma/Components/Panel/PanelTab.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/PanelTab.razor.cs
@@ -1,0 +1,57 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// PanelTab component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class PanelTab : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames =>
+        BuildClassNames(
+            Class,
+            (BulmaCssClass.IsActive, IsActive)
+        );
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hyperlink reference.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the hyperlink reference.")]
+    [Parameter]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// Gets or sets the active state.
+    /// <para>
+    /// Default value is <see langword="false" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(false)]
+    [Description("Gets or sets the active state.")]
+    [Parameter]
+    public bool IsActive { get; set; } = false;
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Components/Panel/PanelTabs.razor
+++ b/BlazorExpress.Bulma/Components/Panel/PanelTabs.razor
@@ -1,0 +1,6 @@
+@namespace BlazorExpress.Bulma
+@inherits BulmaComponentBase
+
+<p @ref="@Element" id="@Id" class="@ClassNames" style="@StyleNames" @attributes="@AdditionalAttributes">
+    @ChildContent
+</p>

--- a/BlazorExpress.Bulma/Components/Panel/PanelTabs.razor.cs
+++ b/BlazorExpress.Bulma/Components/Panel/PanelTabs.razor.cs
@@ -1,0 +1,29 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// PanelTabs component
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/" />
+/// </para>
+/// </summary>
+public partial class PanelTabs : BulmaComponentBase
+{
+    #region Properties, Indexers
+
+    protected override string? ClassNames => BuildClassNames(Class, (BulmaCssClass.PanelTabs, true));
+
+    /// <summary>
+    /// Gets or sets the child content.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// </summary>
+    [AddedVersion("1.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the child content.")]
+    [EditorRequired]
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    #endregion
+}

--- a/BlazorExpress.Bulma/Constants/BulmaCssClass.cs
+++ b/BlazorExpress.Bulma/Constants/BulmaCssClass.cs
@@ -376,6 +376,12 @@ public static class BulmaCssClass
     public const string PaginationNext = "pagination-next";
     public const string PaginationPrevious = "pagination-previous";
 
+    public const string Panel = "panel";
+    public const string PanelBlock = "panel-block";
+    public const string PanelHeading = "panel-heading";
+    public const string PanelIcon = "panel-icon";
+    public const string PanelTabs = "panel-tabs";
+
     public const string Progress = "progress";
 
     public const string P5 = "p-5";

--- a/BlazorExpress.Bulma/Enums/Color/PanelColor.cs
+++ b/BlazorExpress.Bulma/Enums/Color/PanelColor.cs
@@ -1,0 +1,22 @@
+namespace BlazorExpress.Bulma;
+
+/// <summary>
+/// Represents the color of a Bulma Panel.
+/// <para>
+///     <see href="https://bulma.io/documentation/components/panel/#colors" />
+/// </para>
+/// </summary>
+public enum PanelColor
+{
+    None,
+    Primary,
+    Link,
+    Info,
+    Success,
+    Warning,
+    Danger,
+    White,
+    Light,
+    Dark,
+    Black
+}

--- a/BlazorExpress.Bulma/Extensions/EnumExtensions.cs
+++ b/BlazorExpress.Bulma/Extensions/EnumExtensions.cs
@@ -345,6 +345,22 @@ public static class EnumExtensions
             _ => null
         };
 
+    public static string? ToPanelColorClass(this PanelColor color) =>
+        color switch
+        {
+            PanelColor.Primary => BulmaCssClass.IsPrimary,
+            PanelColor.Link => BulmaCssClass.IsLink,
+            PanelColor.Info => BulmaCssClass.IsInfo,
+            PanelColor.Success => BulmaCssClass.IsSuccess,
+            PanelColor.Warning => BulmaCssClass.IsWarning,
+            PanelColor.Danger => BulmaCssClass.IsDanger,
+            PanelColor.White => BulmaCssClass.IsWhite,
+            PanelColor.Light => BulmaCssClass.IsLight,
+            PanelColor.Dark => BulmaCssClass.IsDark,
+            PanelColor.Black => BulmaCssClass.IsBlack,
+            _ => null
+        };
+
     public static string? ToProgressBarColorClass(this ProgressBarColor color) =>
         color switch
         {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Install with [NuGet](https://www.nuget.org/): `Install-Package BlazorExpress.Bul
 | Navbar | [Docs](https://bulma.blazorexpress.com/docs/navbar) | [Demos](https://bulma.blazorexpress.com/demos/navbar) |
 | Notification | [Docs](https://bulma.blazorexpress.com/docs/notification) | [Demos](https://bulma.blazorexpress.com/demos/notification) |
 | Pagination | [Docs](https://bulma.blazorexpress.com/docs/pagination) | [Demos](https://bulma.blazorexpress.com/demos/pagination) |
+| Panel | [Docs](https://bulma.blazorexpress.com/docs/panel) | [Demos](https://bulma.blazorexpress.com/demos/panel) |
 | Pdf Viewer | [Docs](https://bulma.blazorexpress.com/docs/pdf-viewer) | [Demos](https://bulma.blazorexpress.com/demos/pdf-viewer) |
 | Progress Bar | [Docs](https://bulma.blazorexpress.com/docs/progress-bar) | [Demos](https://bulma.blazorexpress.com/demos/progress-bar) |
 | Script Loader | [Docs](https://bulma.blazorexpress.com/docs/script-loader) | [Demos](https://bulma.blazorexpress.com/demos/script-loader) |

--- a/docs/agents/workflow-dependency-maintenance-rules.md
+++ b/docs/agents/workflow-dependency-maintenance-rules.md
@@ -89,7 +89,7 @@ Repository examples:
 ## Requirement Clarification Rule
 
 Before implementation:
-- Analyze the provided requirements for ambiguity, missing decisions, or conflicting expectations.
+- Always analyze the provided requirements for ambiguity, missing decisions, or conflicting expectations before starting any new implementation.
 - If any ambiguity remains that could materially affect the implementation, ask clarifying questions before making code changes.
 - Ask one clarification question at a time.
 - For each clarification question, provide:
@@ -98,7 +98,7 @@ Before implementation:
   - one recommended option
   - a short justification for the recommended option
 - Wait for the user's answer before asking the next clarification question or starting implementation.
-- If the requirement is already clear enough to implement safely, proceed without inventing unnecessary questions.
+- If the requirement is already clear enough to implement safely, say so briefly in a user-facing note and then proceed without inventing unnecessary questions.
 
 Generic example:
 - if a component change request does not specify whether the new behavior should be opt-in or default, ask that decision first before editing parameters or rendering logic

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -47,6 +47,7 @@ Install with [NuGet](https://www.nuget.org/): `Install-Package BlazorExpress.Bul
 | Navbar | [Docs](https://bulma.blazorexpress.com/docs/navbar) | [Demos](https://bulma.blazorexpress.com/demos/navbar) |
 | Notification | [Docs](https://bulma.blazorexpress.com/docs/notification) | [Demos](https://bulma.blazorexpress.com/demos/notification) |
 | Pagination | [Docs](https://bulma.blazorexpress.com/docs/pagination) | [Demos](https://bulma.blazorexpress.com/demos/pagination) |
+| Panel | [Docs](https://bulma.blazorexpress.com/docs/panel) | [Demos](https://bulma.blazorexpress.com/demos/panel) |
 | Pdf Viewer | [Docs](https://bulma.blazorexpress.com/docs/pdf-viewer) | [Demos](https://bulma.blazorexpress.com/demos/pdf-viewer) |
 | Progress Bar | [Docs](https://bulma.blazorexpress.com/docs/progress-bar) | [Demos](https://bulma.blazorexpress.com/demos/progress-bar) |
 | Script Loader | [Docs](https://bulma.blazorexpress.com/docs/script-loader) | [Demos](https://bulma.blazorexpress.com/demos/script-loader) |


### PR DESCRIPTION
- Introduced the Panel component family to mirror Bulma's panel structure, including Panel, PanelBlock, PanelHeading, PanelTabs, and PanelTab.
- Implemented color support for panels using the PanelColor enum.
- Added documentation and demo pages for the new Panel components.
- Updated EnumExtensions to include methods for converting PanelColor to corresponding CSS classes.
- Enhanced README and NuGet documentation to include links to the new Panel component.